### PR TITLE
Implement Zeek log processing pipeline

### DIFF
--- a/flink_zeek/app_processor.py
+++ b/flink_zeek/app_processor.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .models import PacketSequence, SampleFile
+
+
+class ApplicationProcessor:
+    """Aggregate packet sequences into sample files per application."""
+
+    def __init__(self, threshold: int = 100, batch_size: int = 50):
+        self.threshold = threshold
+        self.batch_size = batch_size
+        self.app_queues: Dict[str, List[PacketSequence]] = {}
+        self.user_info: Dict[str, str] = {}
+
+    def process(self, seq: PacketSequence, user_name: str | None = None) -> List[SampleFile]:
+        if user_name:
+            self.user_info[seq.user_id] = user_name
+
+        queue = self.app_queues.setdefault(seq.app_id, [])
+        queue.append(seq)
+
+        result: List[SampleFile] = []
+        if len(queue) >= self.threshold:
+            result.extend(self._emit_batches(seq.app_id))
+
+        return result
+
+    def flush_app(self, app_id: str) -> List[SampleFile]:
+        """Flush all remaining sequences for ``app_id`` as a single sample file."""
+        queue = self.app_queues.pop(app_id, [])
+        if not queue:
+            return []
+        queue.sort(key=lambda s: s.timestamp)
+        return [self._create_sample_file(app_id, queue)]
+
+    def _emit_batches(self, app_id: str) -> List[SampleFile]:
+        queue = self.app_queues[app_id]
+        queue.sort(key=lambda s: s.timestamp)
+        result: List[SampleFile] = []
+        while len(queue) >= self.batch_size:
+            batch = queue[: self.batch_size]
+            del queue[: self.batch_size]
+            result.append(self._create_sample_file(app_id, batch))
+        return result
+
+    def _create_sample_file(self, app_id: str, seqs: List[PacketSequence]) -> SampleFile:
+        user_id = seqs[0].user_id
+        user_name = self.user_info.get(user_id, "")
+        return SampleFile(
+            user_id=user_id,
+            user_name=user_name,
+            app_id=app_id,
+            generation_timestamp=seqs[-1].timestamp,
+            packet_sequences=seqs,
+            metadata={},
+        )

--- a/flink_zeek/models.py
+++ b/flink_zeek/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class UnifiedLog:
+    """Representation of a normalized log event coming from different Zeek topics."""
+
+    timestamp: int
+    uid: str
+    source_ip: str
+    destination_ip: str
+    bytes_length: int
+    user_id: str
+    app_id: str
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PacketSequence:
+    """A chunk of ordered packets belonging to the same session."""
+
+    user_id: str
+    app_id: str
+    timestamp: int
+    packets: List[UnifiedLog]
+
+
+@dataclass
+class SampleFile:
+    """Final sample file ready for downstream detection systems."""
+
+    user_id: str
+    user_name: str
+    app_id: str
+    generation_timestamp: int
+    packet_sequences: List[PacketSequence]
+    metadata: Dict[str, Any]

--- a/flink_zeek/session_processor.py
+++ b/flink_zeek/session_processor.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .models import PacketSequence, UnifiedLog
+
+
+class SessionProcessor:
+    """Aggregate raw logs into ordered packet sequences per session.
+
+    The processor keeps an in-memory buffer for each session ``uid``. When a
+    session times out or the buffer reaches a threshold, a ``PacketSequence`` is
+    emitted.
+    """
+
+    def __init__(self, threshold: int = 100, batch_size: int = 50):
+        self.threshold = threshold
+        self.batch_size = batch_size
+        self.session_buffer: Dict[str, List[UnifiedLog]] = {}
+
+    def process(self, log: UnifiedLog) -> List[PacketSequence]:
+        """Process a single ``UnifiedLog`` and return any generated sequences."""
+
+        result: List[PacketSequence] = []
+        buffer = self.session_buffer.setdefault(log.uid, [])
+        buffer.append(log)
+
+        if log.raw.get("is_timeout"):
+            result.extend(self._flush_session(log.uid))
+        elif len(buffer) >= self.threshold:
+            result.extend(self._emit_batches(log.uid))
+
+        return result
+
+    def _emit_batches(self, uid: str) -> List[PacketSequence]:
+        buffer = self.session_buffer[uid]
+        buffer.sort(key=lambda l: l.timestamp)
+        result: List[PacketSequence] = []
+        while len(buffer) >= self.batch_size:
+            batch = buffer[: self.batch_size]
+            del buffer[: self.batch_size]
+            result.append(
+                PacketSequence(
+                    user_id=batch[0].user_id,
+                    app_id=batch[0].app_id,
+                    timestamp=batch[0].timestamp,
+                    packets=batch,
+                )
+            )
+        return result
+
+    def _flush_session(self, uid: str) -> List[PacketSequence]:
+        buffer = self.session_buffer.pop(uid, [])
+        if not buffer:
+            return []
+        buffer.sort(key=lambda l: l.timestamp)
+        return [
+            PacketSequence(
+                user_id=buffer[0].user_id,
+                app_id=buffer[0].app_id,
+                timestamp=buffer[0].timestamp,
+                packets=buffer,
+            )
+        ]

--- a/flink_zeek/tlv.py
+++ b/flink_zeek/tlv.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+def parse_user_id_tlv(tlv: str) -> Optional[str]:
+    """Parse a TLV encoded hex string and return the embedded user_id.
+
+    The TLV format is expected to be: [type][length][value]. All parts are
+    encoded as hexadecimal characters. Only the ``value`` part is returned and
+    decoded as UTF-8 string. If parsing fails, ``None`` is returned.
+    """
+
+    try:
+        data = bytes.fromhex(tlv)
+    except ValueError:
+        return None
+
+    if len(data) < 2:
+        return None
+
+    length = data[1]
+    value = data[2 : 2 + length]
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError:
+        return None

--- a/main.py
+++ b/main.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Iterable
+
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors import FlinkKafkaConsumer, FlinkKafkaProducer
+from pyflink.common.serialization import SimpleStringSchema
+
+from flink_zeek.models import UnifiedLog
+from flink_zeek.tlv import parse_user_id_tlv
+from flink_zeek.session_processor import SessionProcessor
+from flink_zeek.app_processor import ApplicationProcessor
+
+
+def deserialize_log(raw: str) -> UnifiedLog:
+    data = json.loads(raw)
+    user_id = parse_user_id_tlv(data.get("user_id_tlv", "")) or ""
+    if "content_length_pair" in data:
+        bytes_length = sum(data.get("content_length_pair", []))
+        app_id = data.get("host", "")
+    elif "payload_bytes" in data:
+        bytes_length = data.get("payload_bytes", 0)
+        app_id = data.get("host", "")
+    else:
+        bytes_length = data.get("record_length", 0)
+        app_id = data.get("sni", "")
+
+    return UnifiedLog(
+        timestamp=data.get("timestamp", 0),
+        uid=data.get("uid", ""),
+        source_ip=data.get("source_ip", ""),
+        destination_ip=data.get("destination_ip", ""),
+        bytes_length=bytes_length,
+        user_id=user_id,
+        app_id=app_id,
+        raw=data,
+    )
+
+
+def main() -> None:
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+
+    kafka_props = {"bootstrap.servers": "kafka:9092", "group.id": "flink-zeek"}
+
+    topics = [
+        "zeek_http_log",
+        "zeek_tcp_log",
+        "zeek_udp_log",
+        "zeek_quic_log",
+        "zeek_https_log",
+        "zeek_session_timeout",
+    ]
+
+    consumer = FlinkKafkaConsumer(topics, SimpleStringSchema(), kafka_props)
+    stream = env.add_source(consumer).map(deserialize_log)
+
+    session_proc = SessionProcessor()
+    sequences = stream.key_by(lambda log: log.user_id).flat_map(lambda log: session_proc.process(log))
+
+    app_proc = ApplicationProcessor()
+    samples = sequences.key_by(lambda seq: seq.user_id).flat_map(lambda seq: app_proc.process(seq))
+
+    producer = FlinkKafkaProducer(
+        topic="detection_sample_files",
+        serialization_schema=SimpleStringSchema(),
+        producer_config=kafka_props,
+    )
+
+    samples.map(lambda s: json.dumps(dataclasses.asdict(s))).add_sink(producer)
+
+    env.execute("flink-zeek-pipeline")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyflink
+pytest

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -1,0 +1,10 @@
+from flink_zeek.tlv import parse_user_id_tlv
+
+
+def test_parse_user_id_tlv():
+    tlv = "010A5A68616E6773616E"
+    assert parse_user_id_tlv(tlv) == "Zhangsan"
+
+
+def test_parse_user_id_tlv_invalid():
+    assert parse_user_id_tlv("ZZZZ") is None


### PR DESCRIPTION
## Summary
- add data models for unified logs, packet sequences and sample files
- parse TLV-encoded user ids
- buffer logs by session and app to emit packet sequences and sample files
- provide a Flink streaming job wiring Kafka topics and processors

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689315bdc50483229862982a92ec19ff